### PR TITLE
Repository cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@ Makefile
 Makefile.old
 MANIFEST.bak
 META.yml
+META.json
 MYMETA.yml
+MYMETA.json
 nytprof.out
 pm_to_blib
 *.out
+pmtools-*


### PR DESCRIPTION
3 patches that cleanup the Git repository:
- fix file permissions for Unix
- remove unwanted files
- add some missing files to ignore to `.gitignore`
