### PR TITLE
VERSION to reflect proper version number

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 use ExtUtils::MakeMaker;
 WriteMakefile(
-	VERSION => '1.00',
+	VERSION => '1.30',
 	NAME => "pmtools",
         DISTNAME => "pmtools",
 	EXE_FILES => [  basepods, faqpods, modpods, pfcat, plxload,


### PR DESCRIPTION
Installing via cpanm would not work with cpanm pmtools so I used cpanm Devel::Loaded which worked but the output was like so:

Fetching http://www.cpan.org/authors/id/M/ML/MLFISHER/pmtools-1.30.tar.gz ... OK
Configuring pmtools-1.30 ... OK
Building and testing pmtools-1.00 ... OK
Successfully installed pmtools-1.00

I was confused by this so I poked around and it appears this might be the issue.
